### PR TITLE
Support for witness assumptions made to assignments of non-deterministic values (partially)

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,3 @@
+example witness is incorrect (does not give value to tmp_guard, which would be relevant)
+so we can not validate it
+but we can generate the test and use the present witness infos

--- a/example/mix000.opt.i
+++ b/example/mix000.opt.i
@@ -1,0 +1,846 @@
+extern _Bool __VERIFIER_nondet_bool(void);
+extern void abort(void);
+void assume_abort_if_not(int cond) {
+  if(!cond) {abort();}
+}
+extern _Bool __VERIFIER_nondet_bool(void);
+extern void abort(void);
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+void reach_error() { ((void) sizeof ((0) ? 1 : 0), __extension__ ({ if (0) ; else __assert_fail ("0", "mix000.opt.c", 9, __extension__ __PRETTY_FUNCTION__); })); }
+void __VERIFIER_assert(int expression) { if (!expression) { ERROR: {reach_error();abort();} }; return; }
+extern void __VERIFIER_atomic_begin();
+extern void __VERIFIER_atomic_end();
+
+extern void __assert_fail (const char *__assertion, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert_perror_fail (int __errnum, const char *__file,
+      unsigned int __line, const char *__function)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+extern void __assert (const char *__assertion, const char *__file, int __line)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+__extension__ typedef signed long long int __int64_t;
+__extension__ typedef unsigned long long int __uint64_t;
+__extension__ typedef long long int __quad_t;
+__extension__ typedef unsigned long long int __u_quad_t;
+__extension__ typedef long long int __intmax_t;
+__extension__ typedef unsigned long long int __uintmax_t;
+__extension__ typedef __u_quad_t __dev_t;
+__extension__ typedef unsigned int __uid_t;
+__extension__ typedef unsigned int __gid_t;
+__extension__ typedef unsigned long int __ino_t;
+__extension__ typedef __u_quad_t __ino64_t;
+__extension__ typedef unsigned int __mode_t;
+__extension__ typedef unsigned int __nlink_t;
+__extension__ typedef long int __off_t;
+__extension__ typedef __quad_t __off64_t;
+__extension__ typedef int __pid_t;
+__extension__ typedef struct { int __val[2]; } __fsid_t;
+__extension__ typedef long int __clock_t;
+__extension__ typedef unsigned long int __rlim_t;
+__extension__ typedef __u_quad_t __rlim64_t;
+__extension__ typedef unsigned int __id_t;
+__extension__ typedef long int __time_t;
+__extension__ typedef unsigned int __useconds_t;
+__extension__ typedef long int __suseconds_t;
+__extension__ typedef int __daddr_t;
+__extension__ typedef int __key_t;
+__extension__ typedef int __clockid_t;
+__extension__ typedef void * __timer_t;
+__extension__ typedef long int __blksize_t;
+__extension__ typedef long int __blkcnt_t;
+__extension__ typedef __quad_t __blkcnt64_t;
+__extension__ typedef unsigned long int __fsblkcnt_t;
+__extension__ typedef __u_quad_t __fsblkcnt64_t;
+__extension__ typedef unsigned long int __fsfilcnt_t;
+__extension__ typedef __u_quad_t __fsfilcnt64_t;
+__extension__ typedef int __fsword_t;
+__extension__ typedef int __ssize_t;
+__extension__ typedef long int __syscall_slong_t;
+__extension__ typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef char *__caddr_t;
+__extension__ typedef int __intptr_t;
+__extension__ typedef unsigned int __socklen_t;
+typedef int __sig_atomic_t;
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __builtin_bswap32 (__bsx);
+}
+static __inline __uint64_t
+__bswap_64 (__uint64_t __bsx)
+{
+  return __builtin_bswap64 (__bsx);
+}
+static __inline __uint16_t
+__uint16_identity (__uint16_t __x)
+{
+  return __x;
+}
+static __inline __uint32_t
+__uint32_identity (__uint32_t __x)
+{
+  return __x;
+}
+static __inline __uint64_t
+__uint64_identity (__uint64_t __x)
+{
+  return __x;
+}
+typedef unsigned int size_t;
+typedef __time_t time_t;
+struct timespec
+{
+  __time_t tv_sec;
+  __syscall_slong_t tv_nsec;
+};
+typedef __pid_t pid_t;
+struct sched_param
+{
+  int sched_priority;
+};
+
+
+typedef unsigned long int __cpu_mask;
+typedef struct
+{
+  __cpu_mask __bits[1024 / (8 * sizeof (__cpu_mask))];
+} cpu_set_t;
+
+extern int __sched_cpucount (size_t __setsize, const cpu_set_t *__setp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern cpu_set_t *__sched_cpualloc (size_t __count) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern void __sched_cpufree (cpu_set_t *__set) __attribute__ ((__nothrow__ , __leaf__));
+
+
+extern int sched_setparam (__pid_t __pid, const struct sched_param *__param)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int sched_getparam (__pid_t __pid, struct sched_param *__param) __attribute__ ((__nothrow__ , __leaf__));
+extern int sched_setscheduler (__pid_t __pid, int __policy,
+          const struct sched_param *__param) __attribute__ ((__nothrow__ , __leaf__));
+extern int sched_getscheduler (__pid_t __pid) __attribute__ ((__nothrow__ , __leaf__));
+extern int sched_yield (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int sched_get_priority_max (int __algorithm) __attribute__ ((__nothrow__ , __leaf__));
+extern int sched_get_priority_min (int __algorithm) __attribute__ ((__nothrow__ , __leaf__));
+extern int sched_rr_get_interval (__pid_t __pid, struct timespec *__t) __attribute__ ((__nothrow__ , __leaf__));
+
+typedef __clock_t clock_t;
+struct tm
+{
+  int tm_sec;
+  int tm_min;
+  int tm_hour;
+  int tm_mday;
+  int tm_mon;
+  int tm_year;
+  int tm_wday;
+  int tm_yday;
+  int tm_isdst;
+  long int tm_gmtoff;
+  const char *tm_zone;
+};
+typedef __clockid_t clockid_t;
+typedef __timer_t timer_t;
+struct itimerspec
+  {
+    struct timespec it_interval;
+    struct timespec it_value;
+  };
+struct sigevent;
+struct __locale_struct
+{
+  struct __locale_data *__locales[13];
+  const unsigned short int *__ctype_b;
+  const int *__ctype_tolower;
+  const int *__ctype_toupper;
+  const char *__names[13];
+};
+typedef struct __locale_struct *__locale_t;
+typedef __locale_t locale_t;
+
+extern clock_t clock (void) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t time (time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern double difftime (time_t __time1, time_t __time0)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern time_t mktime (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime (char *__restrict __s, size_t __maxsize,
+   const char *__restrict __format,
+   const struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern size_t strftime_l (char *__restrict __s, size_t __maxsize,
+     const char *__restrict __format,
+     const struct tm *__restrict __tp,
+     locale_t __loc) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *gmtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *gmtime_r (const time_t *__restrict __timer,
+       struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern struct tm *localtime_r (const time_t *__restrict __timer,
+          struct tm *__restrict __tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *asctime (const struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime (const time_t *__timer) __attribute__ ((__nothrow__ , __leaf__));
+extern char *asctime_r (const struct tm *__restrict __tp,
+   char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *ctime_r (const time_t *__restrict __timer,
+        char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
+extern char *__tzname[2];
+extern int __daylight;
+extern long int __timezone;
+extern char *tzname[2];
+extern void tzset (void) __attribute__ ((__nothrow__ , __leaf__));
+extern int daylight;
+extern long int timezone;
+extern int stime (const time_t *__when) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timegm (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern time_t timelocal (struct tm *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int dysize (int __year) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int nanosleep (const struct timespec *__requested_time,
+        struct timespec *__remaining);
+extern int clock_getres (clockid_t __clock_id, struct timespec *__res) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_gettime (clockid_t __clock_id, struct timespec *__tp) __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_settime (clockid_t __clock_id, const struct timespec *__tp)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int clock_nanosleep (clockid_t __clock_id, int __flags,
+       const struct timespec *__req,
+       struct timespec *__rem);
+extern int clock_getcpuclockid (pid_t __pid, clockid_t *__clock_id) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_create (clockid_t __clock_id,
+    struct sigevent *__restrict __evp,
+    timer_t *__restrict __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_delete (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_settime (timer_t __timerid, int __flags,
+     const struct itimerspec *__restrict __value,
+     struct itimerspec *__restrict __ovalue) __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_gettime (timer_t __timerid, struct itimerspec *__value)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int timer_getoverrun (timer_t __timerid) __attribute__ ((__nothrow__ , __leaf__));
+extern int timespec_get (struct timespec *__ts, int __base)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+
+struct __pthread_rwlock_arch_t
+{
+  unsigned int __readers;
+  unsigned int __writers;
+  unsigned int __wrphase_futex;
+  unsigned int __writers_futex;
+  unsigned int __pad3;
+  unsigned int __pad4;
+  unsigned char __flags;
+  unsigned char __shared;
+  signed char __rwelision;
+  unsigned char __pad2;
+  int __cur_writer;
+};
+typedef struct __pthread_internal_slist
+{
+  struct __pthread_internal_slist *__next;
+} __pthread_slist_t;
+struct __pthread_mutex_s
+{
+  int __lock ;
+  unsigned int __count;
+  int __owner;
+  int __kind;
+ 
+  unsigned int __nusers;
+  __extension__ union
+  {
+    struct { short __espins; short __eelision; } __elision_data;
+    __pthread_slist_t __list;
+  };
+ 
+};
+struct __pthread_cond_s
+{
+  __extension__ union
+  {
+    __extension__ unsigned long long int __wseq;
+    struct
+    {
+      unsigned int __low;
+      unsigned int __high;
+    } __wseq32;
+  };
+  __extension__ union
+  {
+    __extension__ unsigned long long int __g1_start;
+    struct
+    {
+      unsigned int __low;
+      unsigned int __high;
+    } __g1_start32;
+  };
+  unsigned int __g_refs[2] ;
+  unsigned int __g_size[2];
+  unsigned int __g1_orig_size;
+  unsigned int __wrefs;
+  unsigned int __g_signals[2];
+};
+typedef unsigned long int pthread_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_mutexattr_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_condattr_t;
+typedef unsigned int pthread_key_t;
+typedef int pthread_once_t;
+union pthread_attr_t
+{
+  char __size[36];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+typedef union
+{
+  struct __pthread_mutex_s __data;
+  char __size[24];
+  long int __align;
+} pthread_mutex_t;
+typedef union
+{
+  struct __pthread_cond_s __data;
+  char __size[48];
+  __extension__ long long int __align;
+} pthread_cond_t;
+typedef union
+{
+  struct __pthread_rwlock_arch_t __data;
+  char __size[32];
+  long int __align;
+} pthread_rwlock_t;
+typedef union
+{
+  char __size[8];
+  long int __align;
+} pthread_rwlockattr_t;
+typedef volatile int pthread_spinlock_t;
+typedef union
+{
+  char __size[20];
+  long int __align;
+} pthread_barrier_t;
+typedef union
+{
+  char __size[4];
+  int __align;
+} pthread_barrierattr_t;
+typedef int __jmp_buf[6];
+enum
+{
+  PTHREAD_CREATE_JOINABLE,
+  PTHREAD_CREATE_DETACHED
+};
+enum
+{
+  PTHREAD_MUTEX_TIMED_NP,
+  PTHREAD_MUTEX_RECURSIVE_NP,
+  PTHREAD_MUTEX_ERRORCHECK_NP,
+  PTHREAD_MUTEX_ADAPTIVE_NP
+  ,
+  PTHREAD_MUTEX_NORMAL = PTHREAD_MUTEX_TIMED_NP,
+  PTHREAD_MUTEX_RECURSIVE = PTHREAD_MUTEX_RECURSIVE_NP,
+  PTHREAD_MUTEX_ERRORCHECK = PTHREAD_MUTEX_ERRORCHECK_NP,
+  PTHREAD_MUTEX_DEFAULT = PTHREAD_MUTEX_NORMAL
+};
+enum
+{
+  PTHREAD_MUTEX_STALLED,
+  PTHREAD_MUTEX_STALLED_NP = PTHREAD_MUTEX_STALLED,
+  PTHREAD_MUTEX_ROBUST,
+  PTHREAD_MUTEX_ROBUST_NP = PTHREAD_MUTEX_ROBUST
+};
+enum
+{
+  PTHREAD_PRIO_NONE,
+  PTHREAD_PRIO_INHERIT,
+  PTHREAD_PRIO_PROTECT
+};
+enum
+{
+  PTHREAD_RWLOCK_PREFER_READER_NP,
+  PTHREAD_RWLOCK_PREFER_WRITER_NP,
+  PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP,
+  PTHREAD_RWLOCK_DEFAULT_NP = PTHREAD_RWLOCK_PREFER_READER_NP
+};
+enum
+{
+  PTHREAD_INHERIT_SCHED,
+  PTHREAD_EXPLICIT_SCHED
+};
+enum
+{
+  PTHREAD_SCOPE_SYSTEM,
+  PTHREAD_SCOPE_PROCESS
+};
+enum
+{
+  PTHREAD_PROCESS_PRIVATE,
+  PTHREAD_PROCESS_SHARED
+};
+struct _pthread_cleanup_buffer
+{
+  void (*__routine) (void *);
+  void *__arg;
+  int __canceltype;
+  struct _pthread_cleanup_buffer *__prev;
+};
+enum
+{
+  PTHREAD_CANCEL_ENABLE,
+  PTHREAD_CANCEL_DISABLE
+};
+enum
+{
+  PTHREAD_CANCEL_DEFERRED,
+  PTHREAD_CANCEL_ASYNCHRONOUS
+};
+
+extern int pthread_create (pthread_t *__restrict __newthread,
+      const pthread_attr_t *__restrict __attr,
+      void *(*__start_routine) (void *),
+      void *__restrict __arg) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 3)));
+extern void pthread_exit (void *__retval) __attribute__ ((__noreturn__));
+extern int pthread_join (pthread_t __th, void **__thread_return);
+extern int pthread_detach (pthread_t __th) __attribute__ ((__nothrow__ , __leaf__));
+extern pthread_t pthread_self (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int pthread_equal (pthread_t __thread1, pthread_t __thread2)
+  __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int pthread_attr_init (pthread_attr_t *__attr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_destroy (pthread_attr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_getdetachstate (const pthread_attr_t *__attr,
+     int *__detachstate)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_setdetachstate (pthread_attr_t *__attr,
+     int __detachstate)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_getguardsize (const pthread_attr_t *__attr,
+          size_t *__guardsize)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_setguardsize (pthread_attr_t *__attr,
+          size_t __guardsize)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_getschedparam (const pthread_attr_t *__restrict __attr,
+           struct sched_param *__restrict __param)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_setschedparam (pthread_attr_t *__restrict __attr,
+           const struct sched_param *__restrict
+           __param) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_getschedpolicy (const pthread_attr_t *__restrict
+     __attr, int *__restrict __policy)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_setschedpolicy (pthread_attr_t *__attr, int __policy)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_getinheritsched (const pthread_attr_t *__restrict
+      __attr, int *__restrict __inherit)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_setinheritsched (pthread_attr_t *__attr,
+      int __inherit)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_getscope (const pthread_attr_t *__restrict __attr,
+      int *__restrict __scope)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_setscope (pthread_attr_t *__attr, int __scope)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_getstackaddr (const pthread_attr_t *__restrict
+          __attr, void **__restrict __stackaddr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2))) __attribute__ ((__deprecated__));
+extern int pthread_attr_setstackaddr (pthread_attr_t *__attr,
+          void *__stackaddr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) __attribute__ ((__deprecated__));
+extern int pthread_attr_getstacksize (const pthread_attr_t *__restrict
+          __attr, size_t *__restrict __stacksize)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_attr_setstacksize (pthread_attr_t *__attr,
+          size_t __stacksize)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_attr_getstack (const pthread_attr_t *__restrict __attr,
+      void **__restrict __stackaddr,
+      size_t *__restrict __stacksize)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int pthread_attr_setstack (pthread_attr_t *__attr, void *__stackaddr,
+      size_t __stacksize) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_setschedparam (pthread_t __target_thread, int __policy,
+      const struct sched_param *__param)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3)));
+extern int pthread_getschedparam (pthread_t __target_thread,
+      int *__restrict __policy,
+      struct sched_param *__restrict __param)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
+extern int pthread_setschedprio (pthread_t __target_thread, int __prio)
+     __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_once (pthread_once_t *__once_control,
+    void (*__init_routine) (void)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_setcancelstate (int __state, int *__oldstate);
+extern int pthread_setcanceltype (int __type, int *__oldtype);
+extern int pthread_cancel (pthread_t __th);
+extern void pthread_testcancel (void);
+typedef struct
+{
+  struct
+  {
+    __jmp_buf __cancel_jmp_buf;
+    int __mask_was_saved;
+  } __cancel_jmp_buf[1];
+  void *__pad[4];
+} __pthread_unwind_buf_t __attribute__ ((__aligned__));
+struct __pthread_cleanup_frame
+{
+  void (*__cancel_routine) (void *);
+  void *__cancel_arg;
+  int __do_it;
+  int __cancel_type;
+};
+extern void __pthread_register_cancel (__pthread_unwind_buf_t *__buf)
+     __attribute__ ((__regparm__ (1)));
+extern void __pthread_unregister_cancel (__pthread_unwind_buf_t *__buf)
+  __attribute__ ((__regparm__ (1)));
+extern void __pthread_unwind_next (__pthread_unwind_buf_t *__buf)
+     __attribute__ ((__regparm__ (1))) __attribute__ ((__noreturn__))
+     __attribute__ ((__weak__))
+     ;
+struct __jmp_buf_tag;
+extern int __sigsetjmp (struct __jmp_buf_tag *__env, int __savemask) __attribute__ ((__nothrow__));
+extern int pthread_mutex_init (pthread_mutex_t *__mutex,
+          const pthread_mutexattr_t *__mutexattr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutex_destroy (pthread_mutex_t *__mutex)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutex_trylock (pthread_mutex_t *__mutex)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutex_lock (pthread_mutex_t *__mutex)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutex_timedlock (pthread_mutex_t *__restrict __mutex,
+        const struct timespec *__restrict
+        __abstime) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_mutex_unlock (pthread_mutex_t *__mutex)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutex_getprioceiling (const pthread_mutex_t *
+      __restrict __mutex,
+      int *__restrict __prioceiling)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_mutex_setprioceiling (pthread_mutex_t *__restrict __mutex,
+      int __prioceiling,
+      int *__restrict __old_ceiling)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 3)));
+extern int pthread_mutex_consistent (pthread_mutex_t *__mutex)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutexattr_init (pthread_mutexattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutexattr_destroy (pthread_mutexattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutexattr_getpshared (const pthread_mutexattr_t *
+      __restrict __attr,
+      int *__restrict __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_mutexattr_setpshared (pthread_mutexattr_t *__attr,
+      int __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutexattr_gettype (const pthread_mutexattr_t *__restrict
+          __attr, int *__restrict __kind)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_mutexattr_settype (pthread_mutexattr_t *__attr, int __kind)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutexattr_getprotocol (const pthread_mutexattr_t *
+       __restrict __attr,
+       int *__restrict __protocol)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_mutexattr_setprotocol (pthread_mutexattr_t *__attr,
+       int __protocol)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutexattr_getprioceiling (const pthread_mutexattr_t *
+          __restrict __attr,
+          int *__restrict __prioceiling)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_mutexattr_setprioceiling (pthread_mutexattr_t *__attr,
+          int __prioceiling)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_mutexattr_getrobust (const pthread_mutexattr_t *__attr,
+     int *__robustness)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_mutexattr_setrobust (pthread_mutexattr_t *__attr,
+     int __robustness)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlock_init (pthread_rwlock_t *__restrict __rwlock,
+    const pthread_rwlockattr_t *__restrict
+    __attr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlock_destroy (pthread_rwlock_t *__rwlock)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlock_rdlock (pthread_rwlock_t *__rwlock)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlock_tryrdlock (pthread_rwlock_t *__rwlock)
+  __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlock_timedrdlock (pthread_rwlock_t *__restrict __rwlock,
+           const struct timespec *__restrict
+           __abstime) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_rwlock_wrlock (pthread_rwlock_t *__rwlock)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlock_trywrlock (pthread_rwlock_t *__rwlock)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlock_timedwrlock (pthread_rwlock_t *__restrict __rwlock,
+           const struct timespec *__restrict
+           __abstime) __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_rwlock_unlock (pthread_rwlock_t *__rwlock)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlockattr_init (pthread_rwlockattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlockattr_destroy (pthread_rwlockattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlockattr_getpshared (const pthread_rwlockattr_t *
+       __restrict __attr,
+       int *__restrict __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_rwlockattr_setpshared (pthread_rwlockattr_t *__attr,
+       int __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_rwlockattr_getkind_np (const pthread_rwlockattr_t *
+       __restrict __attr,
+       int *__restrict __pref)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_rwlockattr_setkind_np (pthread_rwlockattr_t *__attr,
+       int __pref) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_cond_init (pthread_cond_t *__restrict __cond,
+         const pthread_condattr_t *__restrict __cond_attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_cond_destroy (pthread_cond_t *__cond)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_cond_signal (pthread_cond_t *__cond)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_cond_broadcast (pthread_cond_t *__cond)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_cond_wait (pthread_cond_t *__restrict __cond,
+         pthread_mutex_t *__restrict __mutex)
+     __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_cond_timedwait (pthread_cond_t *__restrict __cond,
+       pthread_mutex_t *__restrict __mutex,
+       const struct timespec *__restrict __abstime)
+     __attribute__ ((__nonnull__ (1, 2, 3)));
+extern int pthread_condattr_init (pthread_condattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_condattr_destroy (pthread_condattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_condattr_getpshared (const pthread_condattr_t *
+     __restrict __attr,
+     int *__restrict __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_condattr_setpshared (pthread_condattr_t *__attr,
+     int __pshared) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_condattr_getclock (const pthread_condattr_t *
+          __restrict __attr,
+          __clockid_t *__restrict __clock_id)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_condattr_setclock (pthread_condattr_t *__attr,
+          __clockid_t __clock_id)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_spin_init (pthread_spinlock_t *__lock, int __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_spin_destroy (pthread_spinlock_t *__lock)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_spin_lock (pthread_spinlock_t *__lock)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_spin_trylock (pthread_spinlock_t *__lock)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_spin_unlock (pthread_spinlock_t *__lock)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_barrier_init (pthread_barrier_t *__restrict __barrier,
+     const pthread_barrierattr_t *__restrict
+     __attr, unsigned int __count)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_barrier_destroy (pthread_barrier_t *__barrier)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_barrier_wait (pthread_barrier_t *__barrier)
+     __attribute__ ((__nothrow__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_barrierattr_init (pthread_barrierattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_barrierattr_destroy (pthread_barrierattr_t *__attr)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_barrierattr_getpshared (const pthread_barrierattr_t *
+        __restrict __attr,
+        int *__restrict __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
+extern int pthread_barrierattr_setpshared (pthread_barrierattr_t *__attr,
+        int __pshared)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_key_create (pthread_key_t *__key,
+          void (*__destr_function) (void *))
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
+extern int pthread_key_delete (pthread_key_t __key) __attribute__ ((__nothrow__ , __leaf__));
+extern void *pthread_getspecific (pthread_key_t __key) __attribute__ ((__nothrow__ , __leaf__));
+extern int pthread_setspecific (pthread_key_t __key,
+    const void *__pointer) __attribute__ ((__nothrow__ , __leaf__)) ;
+extern int pthread_getcpuclockid (pthread_t __thread_id,
+      __clockid_t *__clock_id)
+     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern int pthread_atfork (void (*__prepare) (void),
+      void (*__parent) (void),
+      void (*__child) (void)) __attribute__ ((__nothrow__ , __leaf__));
+
+void * P0(void *arg);
+void * P1(void *arg);
+void fence();
+void isync();
+void lwfence();
+int __unbuffered_cnt;
+int __unbuffered_cnt = 0;
+int __unbuffered_p0_EAX;
+int __unbuffered_p0_EAX = 0;
+int __unbuffered_p0_EBX;
+int __unbuffered_p0_EBX = 0;
+int __unbuffered_p1_EAX;
+int __unbuffered_p1_EAX = 0;
+int __unbuffered_p1_EBX;
+int __unbuffered_p1_EBX = 0;
+_Bool main$tmp_guard0;
+_Bool main$tmp_guard1;
+int x;
+int x = 0;
+_Bool x$flush_delayed;
+int x$mem_tmp;
+_Bool x$r_buff0_thd0;
+_Bool x$r_buff0_thd1;
+_Bool x$r_buff0_thd2;
+_Bool x$r_buff1_thd0;
+_Bool x$r_buff1_thd1;
+_Bool x$r_buff1_thd2;
+_Bool x$read_delayed;
+int *x$read_delayed_var;
+int x$w_buff0;
+_Bool x$w_buff0_used;
+int x$w_buff1;
+_Bool x$w_buff1_used;
+int y;
+int y = 0;
+_Bool weak$$choice0;
+_Bool weak$$choice2;
+void * P0(void *arg)
+{
+  __VERIFIER_atomic_begin();
+  y = 1;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  __unbuffered_p0_EAX = y;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  weak$$choice0 = __VERIFIER_nondet_bool();
+  weak$$choice2 = __VERIFIER_nondet_bool();
+  x$flush_delayed = weak$$choice2;
+  x$mem_tmp = x;
+  x = !x$w_buff0_used || !x$r_buff0_thd1 && !x$w_buff1_used || !x$r_buff0_thd1 && !x$r_buff1_thd1 ? x : (x$w_buff0_used && x$r_buff0_thd1 ? x$w_buff0 : x$w_buff1);
+  x$w_buff0 = weak$$choice2 ? x$w_buff0 : (!x$w_buff0_used || !x$r_buff0_thd1 && !x$w_buff1_used || !x$r_buff0_thd1 && !x$r_buff1_thd1 ? x$w_buff0 : (x$w_buff0_used && x$r_buff0_thd1 ? x$w_buff0 : x$w_buff0));
+  x$w_buff1 = weak$$choice2 ? x$w_buff1 : (!x$w_buff0_used || !x$r_buff0_thd1 && !x$w_buff1_used || !x$r_buff0_thd1 && !x$r_buff1_thd1 ? x$w_buff1 : (x$w_buff0_used && x$r_buff0_thd1 ? x$w_buff1 : x$w_buff1));
+  x$w_buff0_used = weak$$choice2 ? x$w_buff0_used : (!x$w_buff0_used || !x$r_buff0_thd1 && !x$w_buff1_used || !x$r_buff0_thd1 && !x$r_buff1_thd1 ? x$w_buff0_used : (x$w_buff0_used && x$r_buff0_thd1 ? (_Bool)0 : x$w_buff0_used));
+  x$w_buff1_used = weak$$choice2 ? x$w_buff1_used : (!x$w_buff0_used || !x$r_buff0_thd1 && !x$w_buff1_used || !x$r_buff0_thd1 && !x$r_buff1_thd1 ? x$w_buff1_used : (x$w_buff0_used && x$r_buff0_thd1 ? (_Bool)0 : (_Bool)0));
+  x$r_buff0_thd1 = weak$$choice2 ? x$r_buff0_thd1 : (!x$w_buff0_used || !x$r_buff0_thd1 && !x$w_buff1_used || !x$r_buff0_thd1 && !x$r_buff1_thd1 ? x$r_buff0_thd1 : (x$w_buff0_used && x$r_buff0_thd1 ? (_Bool)0 : x$r_buff0_thd1));
+  x$r_buff1_thd1 = weak$$choice2 ? x$r_buff1_thd1 : (!x$w_buff0_used || !x$r_buff0_thd1 && !x$w_buff1_used || !x$r_buff0_thd1 && !x$r_buff1_thd1 ? x$r_buff1_thd1 : (x$w_buff0_used && x$r_buff0_thd1 ? (_Bool)0 : (_Bool)0));
+  __unbuffered_p0_EBX = x;
+  x = x$flush_delayed ? x$mem_tmp : x;
+  x$flush_delayed = (_Bool)0;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  __unbuffered_cnt = __unbuffered_cnt + 1;
+  __VERIFIER_atomic_end();
+  return 0;
+}
+void * P1(void *arg)
+{
+  __VERIFIER_atomic_begin();
+  x$w_buff1 = x$w_buff0;
+  x$w_buff0 = 1;
+  x$w_buff1_used = x$w_buff0_used;
+  x$w_buff0_used = (_Bool)1;
+  __VERIFIER_assert(!(x$w_buff1_used && x$w_buff0_used));
+  x$r_buff1_thd0 = x$r_buff0_thd0;
+  x$r_buff1_thd1 = x$r_buff0_thd1;
+  x$r_buff1_thd2 = x$r_buff0_thd2;
+  x$r_buff0_thd2 = (_Bool)1;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  weak$$choice0 = __VERIFIER_nondet_bool();
+  weak$$choice2 = __VERIFIER_nondet_bool();
+  x$flush_delayed = weak$$choice2;
+  x$mem_tmp = x;
+  x = !x$w_buff0_used || !x$r_buff0_thd2 && !x$w_buff1_used || !x$r_buff0_thd2 && !x$r_buff1_thd2 ? x : (x$w_buff0_used && x$r_buff0_thd2 ? x$w_buff0 : x$w_buff1);
+  x$w_buff0 = weak$$choice2 ? x$w_buff0 : (!x$w_buff0_used || !x$r_buff0_thd2 && !x$w_buff1_used || !x$r_buff0_thd2 && !x$r_buff1_thd2 ? x$w_buff0 : (x$w_buff0_used && x$r_buff0_thd2 ? x$w_buff0 : x$w_buff0));
+  x$w_buff1 = weak$$choice2 ? x$w_buff1 : (!x$w_buff0_used || !x$r_buff0_thd2 && !x$w_buff1_used || !x$r_buff0_thd2 && !x$r_buff1_thd2 ? x$w_buff1 : (x$w_buff0_used && x$r_buff0_thd2 ? x$w_buff1 : x$w_buff1));
+  x$w_buff0_used = weak$$choice2 ? x$w_buff0_used : (!x$w_buff0_used || !x$r_buff0_thd2 && !x$w_buff1_used || !x$r_buff0_thd2 && !x$r_buff1_thd2 ? x$w_buff0_used : (x$w_buff0_used && x$r_buff0_thd2 ? (_Bool)0 : x$w_buff0_used));
+  x$w_buff1_used = weak$$choice2 ? x$w_buff1_used : (!x$w_buff0_used || !x$r_buff0_thd2 && !x$w_buff1_used || !x$r_buff0_thd2 && !x$r_buff1_thd2 ? x$w_buff1_used : (x$w_buff0_used && x$r_buff0_thd2 ? (_Bool)0 : (_Bool)0));
+  x$r_buff0_thd2 = weak$$choice2 ? x$r_buff0_thd2 : (!x$w_buff0_used || !x$r_buff0_thd2 && !x$w_buff1_used || !x$r_buff0_thd2 && !x$r_buff1_thd2 ? x$r_buff0_thd2 : (x$w_buff0_used && x$r_buff0_thd2 ? (_Bool)0 : x$r_buff0_thd2));
+  x$r_buff1_thd2 = weak$$choice2 ? x$r_buff1_thd2 : (!x$w_buff0_used || !x$r_buff0_thd2 && !x$w_buff1_used || !x$r_buff0_thd2 && !x$r_buff1_thd2 ? x$r_buff1_thd2 : (x$w_buff0_used && x$r_buff0_thd2 ? (_Bool)0 : (_Bool)0));
+  __unbuffered_p1_EAX = x;
+  x = x$flush_delayed ? x$mem_tmp : x;
+  x$flush_delayed = (_Bool)0;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  __unbuffered_p1_EBX = y;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  x = x$w_buff0_used && x$r_buff0_thd2 ? x$w_buff0 : (x$w_buff1_used && x$r_buff1_thd2 ? x$w_buff1 : x);
+  x$w_buff0_used = x$w_buff0_used && x$r_buff0_thd2 ? (_Bool)0 : x$w_buff0_used;
+  x$w_buff1_used = x$w_buff0_used && x$r_buff0_thd2 || x$w_buff1_used && x$r_buff1_thd2 ? (_Bool)0 : x$w_buff1_used;
+  x$r_buff0_thd2 = x$w_buff0_used && x$r_buff0_thd2 ? (_Bool)0 : x$r_buff0_thd2;
+  x$r_buff1_thd2 = x$w_buff0_used && x$r_buff0_thd2 || x$w_buff1_used && x$r_buff1_thd2 ? (_Bool)0 : x$r_buff1_thd2;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  __unbuffered_cnt = __unbuffered_cnt + 1;
+  __VERIFIER_atomic_end();
+  return 0;
+}
+void fence()
+{
+}
+void isync()
+{
+}
+void lwfence()
+{
+}
+int main()
+{
+  pthread_t t0;
+  pthread_create(&t0, ((void *)0), P0, ((void *)0));
+  pthread_t t1;
+  pthread_create(&t1, ((void *)0), P1, ((void *)0));
+  __VERIFIER_atomic_begin();
+  main$tmp_guard0 = __unbuffered_cnt == 2;
+  __VERIFIER_atomic_end();
+  assume_abort_if_not(main$tmp_guard0);
+  __VERIFIER_atomic_begin();
+  x = x$w_buff0_used && x$r_buff0_thd0 ? x$w_buff0 : (x$w_buff1_used && x$r_buff1_thd0 ? x$w_buff1 : x);
+  x$w_buff0_used = x$w_buff0_used && x$r_buff0_thd0 ? (_Bool)0 : x$w_buff0_used;
+  x$w_buff1_used = x$w_buff0_used && x$r_buff0_thd0 || x$w_buff1_used && x$r_buff1_thd0 ? (_Bool)0 : x$w_buff1_used;
+  x$r_buff0_thd0 = x$w_buff0_used && x$r_buff0_thd0 ? (_Bool)0 : x$r_buff0_thd0;
+  x$r_buff1_thd0 = x$w_buff0_used && x$r_buff0_thd0 || x$w_buff1_used && x$r_buff1_thd0 ? (_Bool)0 : x$r_buff1_thd0;
+  __VERIFIER_atomic_end();
+  __VERIFIER_atomic_begin();
+  main$tmp_guard1 = !(__unbuffered_p0_EAX == 1 && __unbuffered_p0_EBX == 0 && __unbuffered_p1_EAX == 1 && __unbuffered_p1_EBX == 0);
+  __VERIFIER_atomic_end();
+  __VERIFIER_assert(main$tmp_guard1);
+  return 0;
+}

--- a/example/mix000.opt.i.graphml
+++ b/example/mix000.opt.i.graphml
@@ -1,0 +1,1010 @@
+<?xml version="1.0" encoding="UTF-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <key attr.name="sourcecodelang" attr.type="string" for="graph" id="sourcecodelang"/>
+    <key attr.name="creationtime" attr.type="string" for="graph" id="creationtime"/>
+    <key attr.name="witness-type" attr.type="string" for="graph" id="witness-type"/>
+    <key attr.name="producer" attr.type="string" for="graph" id="producer"/>
+    <key attr.name="architecture" attr.type="string" for="graph" id="architecture"/>
+    <key attr.name="programHash" attr.type="string" for="graph" id="programhash"/>
+    <key attr.name="programfile" attr.type="string" for="graph" id="programfile"/>
+    <key attr.name="specification" attr.type="string" for="graph" id="specification"/>
+    <key attr.name="assumption" attr.type="string" for="edge" id="assumption"/>
+    <key attr.name="assumption.scope" attr.type="string" for="edge" id="assumption.scope"/>
+    <key attr.name="assumption.resultfunction" attr.type="string" for="edge" id="assumption.resultfunction"/>
+    <key attr.name="control" attr.type="string" for="edge" id="control"/>
+    <key attr.name="startline" attr.type="string" for="edge" id="startline"/>
+    <key attr.name="endline" attr.type="string" for="edge" id="endline"/>
+    <key attr.name="startoffset" attr.type="string" for="edge" id="startoffset"/>
+    <key attr.name="endoffset" attr.type="string" for="edge" id="endoffset"/>
+    <key attr.name="enterLoopHead" attr.type="string" for="edge" id="enterLoopHead"/>
+    <key attr.name="enterFunction" attr.type="string" for="edge" id="enterFunction"/>
+    <key attr.name="returnFromFunction" attr.type="string" for="edge" id="returnFromFunction"/>
+    <key attr.name="threadId" attr.type="string" for="edge" id="threadId"/>
+    <key attr.name="createThread" attr.type="string" for="edge" id="createThread"/>
+    <key attr.name="stmt" attr.type="string" for="edge" id="stmt"/>
+    <key attr.name="cSource" attr.type="string" for="edge" id="cSource"/>
+    <key attr.name="entry" attr.type="string" for="node" id="entry">
+        <default>false</default>
+    </key>
+    <key attr.name="sink" attr.type="string" for="node" id="sink">
+        <default>false</default>
+    </key>
+    <key attr.name="violation" attr.type="string" for="node" id="violation">
+        <default>false</default>
+    </key>
+    <key attr.name="locationStacks" attr.type="string" for="node" id="locationStacks"/>
+    <key attr.name="sourceLines" attr.type="string" for="node" id="sourceLines"/>
+    <key attr.name="state" attr.type="string" for="node" id="state"/>
+    <graph edgedefault="directed">
+        <data key="witness-type">violation_witness</data>
+        <data key="producer">theta</data>
+        <data key="sourcecodelang">C</data>
+        <data key="specification">CHECK( init(main()), LTL(G ! call(reach_error())) )</data>
+        <data key="programfile">/tmp/xcfa6438726142514960239.json</data>
+        <data key="programhash">1427344bf8c0905b63504a8f0111a13fe3d44cc48057d77274e52687b545a602</data>
+        <data key="architecture">32bit</data>
+        <data key="creationtime">2024-11-05T02:45:49Z</data>
+        <node id="N0">
+            <data key="entry">true</data>
+        </node>
+        <node id="N1">
+            <data key="locationStacks">{0=[main_init {init}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState)</data>
+        </node>
+        <node id="N2">
+            <data key="locationStacks">{0=[main_init {init}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState)</data>
+        </node>
+        <node id="N3"/>
+        <node id="N4">
+            <data key="locationStacks">{0=[__loc_569 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 0) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N5"/>
+        <node id="N6"/>
+        <node id="N7"/>
+        <node id="N8">
+            <data key="locationStacks">{0=[__loc_598 ], 30=[P0_init {init}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 0) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N9"/>
+        <node id="N10"/>
+        <node id="N11">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[P0_init {init}], 32=[P1_init {init}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 0) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N12">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[P0_init {init}], 32=[P1_init {init}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 0) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N13">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[P0_init {init}], 32=[P1_init {init}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 0) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N14">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_66 ], 32=[P1_init {init}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 0) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N15">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_66 ], 32=[__loc_257 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 0) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N16"/>
+        <node id="N17"/>
+        <node id="N18"/>
+        <node id="N19"/>
+        <node id="N20"/>
+        <node id="N21"/>
+        <node id="N22">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_66 ], 32=[__loc_42_719 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 0) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N23"/>
+        <node id="N24"/>
+        <node id="N25"/>
+        <node id="N26"/>
+        <node id="N27"/>
+        <node id="N28"/>
+        <node id="N29"/>
+        <node id="N30"/>
+        <node id="N31">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_66 ], 32=[__loc_338 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 0) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 0) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N32"/>
+        <node id="N33"/>
+        <node id="N34"/>
+        <node id="N35"/>
+        <node id="N36"/>
+        <node id="N37"/>
+        <node id="N38"/>
+        <node id="N39"/>
+        <node id="N40"/>
+        <node id="N41"/>
+        <node id="N42"/>
+        <node id="N43"/>
+        <node id="N44"/>
+        <node id="N45"/>
+        <node id="N46"/>
+        <node id="N47"/>
+        <node id="N48"/>
+        <node id="N49"/>
+        <node id="N50">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_66 ], 32=[__loc_452 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N51"/>
+        <node id="N52"/>
+        <node id="N53"/>
+        <node id="N54">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_66 ], 32=[__loc_471 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 0))</data>
+        </node>
+        <node id="N55"/>
+        <node id="N56"/>
+        <node id="N57"/>
+        <node id="N58">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_85 ], 32=[__loc_471 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 0) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N59"/>
+        <node id="N60"/>
+        <node id="N61"/>
+        <node id="N62">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_104 ], 32=[__loc_471 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N63"/>
+        <node id="N64"/>
+        <node id="N65"/>
+        <node id="N66"/>
+        <node id="N67"/>
+        <node id="N68"/>
+        <node id="N69"/>
+        <node id="N70"/>
+        <node id="N71"/>
+        <node id="N72"/>
+        <node id="N73"/>
+        <node id="N74"/>
+        <node id="N75"/>
+        <node id="N76"/>
+        <node id="N77"/>
+        <node id="N78"/>
+        <node id="N79"/>
+        <node id="N80"/>
+        <node id="N81">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_218 ], 32=[__loc_471 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N82"/>
+        <node id="N83"/>
+        <node id="N84">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[__loc_230 ], 32=[__loc_471 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 0) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N85"/>
+        <node id="N86"/>
+        <node id="N87"/>
+        <node id="N88"/>
+        <node id="N89">
+            <data key="locationStacks">{0=[__loc_603 ], 30=[P0_final {final}], 32=[__loc_471 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 30=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 1) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N90">
+            <data key="locationStacks">{0=[__loc_603 ], 32=[__loc_471 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 1) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 0) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 1) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N91"/>
+        <node id="N92"/>
+        <node id="N93"/>
+        <node id="N94"/>
+        <node id="N95"/>
+        <node id="N96"/>
+        <node id="N97"/>
+        <node id="N98">
+            <data key="locationStacks">{0=[__loc_603 ], 32=[__loc_518 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 1) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N99"/>
+        <node id="N100"/>
+        <node id="N101"/>
+        <node id="N102"/>
+        <node id="N103">
+            <data key="locationStacks">{0=[__loc_603 ], 32=[P1_final {final}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;], 32=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N104">
+            <data key="locationStacks">{0=[__loc_603 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 0) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N105"/>
+        <node id="N106"/>
+        <node id="N107"/>
+        <node id="N108">
+            <data key="locationStacks">{0=[__loc_626 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 1) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N109"/>
+        <node id="N110">
+            <data key="locationStacks">{0=[__loc_8_749 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::assume_abort_if_not::cond 1) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 1) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N111"/>
+        <node id="N112"/>
+        <node id="N113">
+            <data key="locationStacks">{0=[__loc_631 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::assume_abort_if_not::cond 1) (T0::_::assume_abort_if_not_ret 5) (T0::_::call_assume_abort_if_not_ret32 5) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 1) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N114"/>
+        <node id="N115"/>
+        <node id="N116"/>
+        <node id="N117"/>
+        <node id="N118"/>
+        <node id="N119"/>
+        <node id="N120"/>
+        <node id="N121">
+            <data key="locationStacks">{0=[__loc_678 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::assume_abort_if_not::cond 1) (T0::_::assume_abort_if_not_ret 5) (T0::_::call_assume_abort_if_not_ret32 5) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 1) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N122"/>
+        <node id="N123"/>
+        <node id="N124"/>
+        <node id="N125">
+            <data key="locationStacks">{0=[__loc_701 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::assume_abort_if_not::cond 1) (T0::_::assume_abort_if_not_ret 5) (T0::_::call_assume_abort_if_not_ret32 5) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 1) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N126"/>
+        <node id="N127">
+            <data key="locationStacks">{0=[__loc_42_768 ]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::__VERIFIER_assert::expression 0) (T0::_::assume_abort_if_not::cond 1) (T0::_::assume_abort_if_not_ret 5) (T0::_::call_assume_abort_if_not_ret32 5) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 1) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+        <node id="N128"/>
+        <node id="N129">
+            <data key="violation">true</data>
+            <data key="locationStacks">{0=[main_error {error}]}</data>
+            <data key="sourceLines">{0=[&lt;unknown&gt;]}</data>
+            <data key="state">(ExplState (P0_ret 0) (P1_ret 0) (T0::_::__VERIFIER_assert::expression 0) (T0::_::assume_abort_if_not::cond 1) (T0::_::assume_abort_if_not_ret 5) (T0::_::call_assume_abort_if_not_ret32 5) (T0::_::main::t0 0) (T0::_::main::t1 0) (T30::_::P0::arg 0) (T30::_::P0_ret 0) (T32::_::P1::arg 0) (T32::_::P1_ret 0) (T32::_::__VERIFIER_assert::expression 1) (T32::_::__VERIFIER_assert_ret 0) (T32::_::call___VERIFIER_assert_ret16 0) (__unbuffered_cnt 2) (__unbuffered_p0_EAX 1) (__unbuffered_p0_EBX 0) (__unbuffered_p1_EAX 1) (__unbuffered_p1_EBX 0) (main$tmp_guard0 1) (main$tmp_guard1 0) (tmp16_P0::arg 0) (tmp17_P1::arg 0) (weak$$choice0 0) (weak$$choice2 1) (x 1) (x$flush_delayed 0) (x$mem_tmp 0) (x$r_buff0_thd0 0) (x$r_buff0_thd1 0) (x$r_buff0_thd2 1) (x$r_buff1_thd0 0) (x$r_buff1_thd1 0) (x$r_buff1_thd2 0) (x$w_buff0 1) (x$w_buff0_used 0) (x$w_buff1 0) (x$w_buff1_used 0) (y 1))</data>
+        </node>
+          
+        <edge source="N0" target="N1">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N1" target="N2">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N2" target="N3">
+            <data key="control">condition-true</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assume (and (&gt;= T0::_::main::t0 0) (&lt;= T0::_::main::t0 4294967295)))</data>
+        </edge>
+        <edge source="N3" target="N4">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N4" target="N5">
+            <data key="startline">827</data>
+            <data key="endline">827</data>
+            <data key="startoffset">36648</data>
+            <data key="endoffset">36697</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assign tmp16_P0::arg (mod (mod 0 4294967296) 4294967296))</data>
+            <data key="cSource">pthread_create(&amp;t0, ((void *)0), P0, ((void *)0));</data>
+        </edge>
+        <edge source="N5" target="N6">
+            <data key="startline">827</data>
+            <data key="endline">827</data>
+            <data key="startoffset">36648</data>
+            <data key="endoffset">36697</data>
+            <data key="threadId">0</data>
+            <data key="createThread">30</data>
+            <data key="cSource">pthread_create(&amp;t0, ((void *)0), P0, ((void *)0));</data>
+        </edge>
+        <edge source="N6" target="N7">
+            <data key="control">condition-true</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assume (and (&gt;= T0::_::main::t1 0) (&lt;= T0::_::main::t1 4294967295)))</data>
+        </edge>
+        <edge source="N7" target="N8">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N8" target="N9">
+            <data key="startline">829</data>
+            <data key="endline">829</data>
+            <data key="startoffset">36717</data>
+            <data key="endoffset">36766</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assign tmp17_P1::arg (mod (mod 0 4294967296) 4294967296))</data>
+            <data key="cSource">pthread_create(&amp;t1, ((void *)0), P1, ((void *)0));</data>
+        </edge>
+        <edge source="N9" target="N10">
+            <data key="startline">829</data>
+            <data key="endline">829</data>
+            <data key="startoffset">36717</data>
+            <data key="endoffset">36766</data>
+            <data key="threadId">0</data>
+            <data key="createThread">32</data>
+            <data key="cSource">pthread_create(&amp;t1, ((void *)0), P1, ((void *)0));</data>
+        </edge>
+        <edge source="N10" target="N11">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N11" target="N12">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N12" target="N13">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N13" target="N14">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N14" target="N15">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N15" target="N16">
+            <data key="startline">773</data>
+            <data key="endline">773</data>
+            <data key="startoffset">33679</data>
+            <data key="endoffset">33704</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N16" target="N17">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff1 x$w_buff0)</data>
+        </edge>
+        <edge source="N17" target="N18">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff0 1)</data>
+        </edge>
+        <edge source="N18" target="N19">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff1_used x$w_buff0_used)</data>
+        </edge>
+        <edge source="N19" target="N20">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff0_used 1)</data>
+        </edge>
+        <edge source="N20" target="N21">
+            <data key="startline">778</data>
+            <data key="endline">778</data>
+            <data key="startoffset">33814</data>
+            <data key="endoffset">33868</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(assign T32::_::__VERIFIER_assert::expression (ite (= (ite (and (/= 0 x$w_buff1_used) (/= 0 x$w_buff0_used)) 1 0) 0) 1 0))</data>
+            <data key="cSource">__VERIFIER_assert(!(x$w_buff1_used &amp;&amp; x$w_buff0_used));</data>
+        </edge>
+        <edge source="N21" target="N22">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N22" target="N23">
+            <data key="control">condition-false</data>
+            <data key="startline">19</data>
+            <data key="endline">19</data>
+            <data key="startoffset">960</data>
+            <data key="endoffset">1011</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(assume (= (ite (= T32::_::__VERIFIER_assert::expression 0) 1 0) 0))</data>
+            <data key="cSource">if (!expression) { ERROR: {reach_error();abort();} }</data>
+        </edge>
+        <edge source="N23" target="N24">
+            <data key="startline">19</data>
+            <data key="endline">19</data>
+            <data key="startoffset">1014</data>
+            <data key="endoffset">1020</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(assign T32::_::__VERIFIER_assert_ret 0)</data>
+            <data key="cSource">return;</data>
+        </edge>
+        <edge source="N24" target="N25">
+            <data key="startline">778</data>
+            <data key="endline">778</data>
+            <data key="startoffset">33814</data>
+            <data key="endoffset">33868</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(assign T32::_::call___VERIFIER_assert_ret16 0)</data>
+            <data key="cSource">__VERIFIER_assert(!(x$w_buff1_used &amp;&amp; x$w_buff0_used));</data>
+        </edge>
+        <edge source="N25" target="N26">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff1_thd0 x$r_buff0_thd0)</data>
+        </edge>
+        <edge source="N26" target="N27">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff1_thd1 x$r_buff0_thd1)</data>
+        </edge>
+        <edge source="N27" target="N28">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff1_thd2 x$r_buff0_thd2)</data>
+        </edge>
+        <edge source="N28" target="N29">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff0_thd2 1)</data>
+        </edge>
+        <edge source="N29" target="N30">
+            <data key="startline">783</data>
+            <data key="endline">783</data>
+            <data key="startoffset">34006</data>
+            <data key="endoffset">34029</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N30" target="N31">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N31" target="N32">
+            <data key="startline">784</data>
+            <data key="endline">784</data>
+            <data key="startoffset">34033</data>
+            <data key="endoffset">34058</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N32" target="N33">
+            <data key="assumption">weak$$choice0 == 0</data>
+            <data key="startline">785</data>
+            <data key="endline">785</data>
+            <data key="startoffset">34062</data>
+            <data key="endoffset">34102</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(havoc weak$$choice0)</data>
+            <data key="cSource">weak$$choice0 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N33" target="N34">
+            <data key="startline">785</data>
+            <data key="endline">785</data>
+            <data key="startoffset">34062</data>
+            <data key="endoffset">34102</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(assume (and (&gt;= weak$$choice0 0) (&lt;= weak$$choice0 1)))</data>
+            <data key="cSource">weak$$choice0 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N34" target="N35">
+            <data key="assumption">weak$$choice2 == 1</data>
+            <data key="startline">786</data>
+            <data key="endline">786</data>
+            <data key="startoffset">34106</data>
+            <data key="endoffset">34146</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(havoc weak$$choice2)</data>
+            <data key="cSource">weak$$choice2 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N35" target="N36">
+            <data key="startline">786</data>
+            <data key="endline">786</data>
+            <data key="startoffset">34106</data>
+            <data key="endoffset">34146</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(assume (and (&gt;= weak$$choice2 0) (&lt;= weak$$choice2 1)))</data>
+            <data key="cSource">weak$$choice2 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N36" target="N37">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$flush_delayed weak$$choice2)</data>
+        </edge>
+        <edge source="N37" target="N38">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$mem_tmp x)</data>
+        </edge>
+        <edge source="N38" target="N39">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd2 0) 1 0))) 1 0))) 1 0)) x (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) x$w_buff0 x$w_buff1)))</data>
+        </edge>
+        <edge source="N39" target="N40">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff0 (ite (/= 0 weak$$choice2) x$w_buff0 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd2 0) 1 0))) 1 0))) 1 0)) x$w_buff0 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) x$w_buff0 x$w_buff0))))</data>
+        </edge>
+        <edge source="N40" target="N41">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff1 (ite (/= 0 weak$$choice2) x$w_buff1 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd2 0) 1 0))) 1 0))) 1 0)) x$w_buff1 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) x$w_buff1 x$w_buff1))))</data>
+        </edge>
+        <edge source="N41" target="N42">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff0_used (ite (= (ite (/= 0 weak$$choice2) x$w_buff0_used (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd2 0) 1 0))) 1 0))) 1 0)) x$w_buff0_used (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) 0 x$w_buff0_used))) 0) 0 1))</data>
+        </edge>
+        <edge source="N42" target="N43">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff1_used (ite (= (ite (/= 0 weak$$choice2) x$w_buff1_used (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd2 0) 1 0))) 1 0))) 1 0)) x$w_buff1_used (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) 0 0))) 0) 0 1))</data>
+        </edge>
+        <edge source="N43" target="N44">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff0_thd2 (ite (= (ite (/= 0 weak$$choice2) x$r_buff0_thd2 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd2 0) 1 0))) 1 0))) 1 0)) x$r_buff0_thd2 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) 0 x$r_buff0_thd2))) 0) 0 1))</data>
+        </edge>
+        <edge source="N44" target="N45">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff1_thd2 (ite (= (ite (/= 0 weak$$choice2) x$r_buff1_thd2 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd2 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd2 0) 1 0))) 1 0))) 1 0)) x$r_buff1_thd2 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) 0 0))) 0) 0 1))</data>
+        </edge>
+        <edge source="N45" target="N46">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign __unbuffered_p1_EAX x)</data>
+        </edge>
+        <edge source="N46" target="N47">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x (ite (/= 0 x$flush_delayed) x$mem_tmp x))</data>
+        </edge>
+        <edge source="N47" target="N48">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$flush_delayed 0)</data>
+        </edge>
+        <edge source="N48" target="N49">
+            <data key="startline">799</data>
+            <data key="endline">799</data>
+            <data key="startoffset">35786</data>
+            <data key="endoffset">35809</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N49" target="N50">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N50" target="N51">
+            <data key="startline">800</data>
+            <data key="endline">800</data>
+            <data key="startoffset">35813</data>
+            <data key="endoffset">35838</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N51" target="N52">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign __unbuffered_p1_EBX y)</data>
+        </edge>
+        <edge source="N52" target="N53">
+            <data key="startline">802</data>
+            <data key="endline">802</data>
+            <data key="startoffset">35869</data>
+            <data key="endoffset">35892</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N53" target="N54">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N54" target="N55">
+            <data key="startline">742</data>
+            <data key="endline">742</data>
+            <data key="startoffset">31559</data>
+            <data key="endoffset">31584</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N55" target="N56">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign y 1)</data>
+        </edge>
+        <edge source="N56" target="N57">
+            <data key="startline">744</data>
+            <data key="endline">744</data>
+            <data key="startoffset">31597</data>
+            <data key="endoffset">31620</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N57" target="N58">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N58" target="N59">
+            <data key="startline">745</data>
+            <data key="endline">745</data>
+            <data key="startoffset">31624</data>
+            <data key="endoffset">31649</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N59" target="N60">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign __unbuffered_p0_EAX y)</data>
+        </edge>
+        <edge source="N60" target="N61">
+            <data key="startline">747</data>
+            <data key="endline">747</data>
+            <data key="startoffset">31680</data>
+            <data key="endoffset">31703</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N61" target="N62">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N62" target="N63">
+            <data key="startline">748</data>
+            <data key="endline">748</data>
+            <data key="startoffset">31707</data>
+            <data key="endoffset">31732</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N63" target="N64">
+            <data key="assumption">weak$$choice0 == 0</data>
+            <data key="startline">749</data>
+            <data key="endline">749</data>
+            <data key="startoffset">31736</data>
+            <data key="endoffset">31776</data>
+            <data key="threadId">30</data>
+            <data key="stmt">(havoc weak$$choice0)</data>
+            <data key="cSource">weak$$choice0 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N64" target="N65">
+            <data key="startline">749</data>
+            <data key="endline">749</data>
+            <data key="startoffset">31736</data>
+            <data key="endoffset">31776</data>
+            <data key="threadId">30</data>
+            <data key="stmt">(assume (and (&gt;= weak$$choice0 0) (&lt;= weak$$choice0 1)))</data>
+            <data key="cSource">weak$$choice0 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N65" target="N66">
+            <data key="assumption">weak$$choice2 == 1</data>
+            <data key="startline">750</data>
+            <data key="endline">750</data>
+            <data key="startoffset">31780</data>
+            <data key="endoffset">31820</data>
+            <data key="threadId">30</data>
+            <data key="stmt">(havoc weak$$choice2)</data>
+            <data key="cSource">weak$$choice2 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N66" target="N67">
+            <data key="startline">750</data>
+            <data key="endline">750</data>
+            <data key="startoffset">31780</data>
+            <data key="endoffset">31820</data>
+            <data key="threadId">30</data>
+            <data key="stmt">(assume (and (&gt;= weak$$choice2 0) (&lt;= weak$$choice2 1)))</data>
+            <data key="cSource">weak$$choice2 = __VERIFIER_nondet_bool();</data>
+        </edge>
+        <edge source="N67" target="N68">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$flush_delayed weak$$choice2)</data>
+        </edge>
+        <edge source="N68" target="N69">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$mem_tmp x)</data>
+        </edge>
+        <edge source="N69" target="N70">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd1 0) 1 0))) 1 0))) 1 0)) x (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd1)) 1 0)) x$w_buff0 x$w_buff1)))</data>
+        </edge>
+        <edge source="N70" target="N71">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$w_buff0 (ite (/= 0 weak$$choice2) x$w_buff0 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd1 0) 1 0))) 1 0))) 1 0)) x$w_buff0 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd1)) 1 0)) x$w_buff0 x$w_buff0))))</data>
+        </edge>
+        <edge source="N71" target="N72">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$w_buff1 (ite (/= 0 weak$$choice2) x$w_buff1 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd1 0) 1 0))) 1 0))) 1 0)) x$w_buff1 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd1)) 1 0)) x$w_buff1 x$w_buff1))))</data>
+        </edge>
+        <edge source="N72" target="N73">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$w_buff0_used (ite (= (ite (/= 0 weak$$choice2) x$w_buff0_used (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd1 0) 1 0))) 1 0))) 1 0)) x$w_buff0_used (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd1)) 1 0)) 0 x$w_buff0_used))) 0) 0 1))</data>
+        </edge>
+        <edge source="N73" target="N74">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$w_buff1_used (ite (= (ite (/= 0 weak$$choice2) x$w_buff1_used (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd1 0) 1 0))) 1 0))) 1 0)) x$w_buff1_used (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd1)) 1 0)) 0 0))) 0) 0 1))</data>
+        </edge>
+        <edge source="N74" target="N75">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$r_buff0_thd1 (ite (= (ite (/= 0 weak$$choice2) x$r_buff0_thd1 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd1 0) 1 0))) 1 0))) 1 0)) x$r_buff0_thd1 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd1)) 1 0)) 0 x$r_buff0_thd1))) 0) 0 1))</data>
+        </edge>
+        <edge source="N75" target="N76">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$r_buff1_thd1 (ite (= (ite (/= 0 weak$$choice2) x$r_buff1_thd1 (ite (/= 0 (ite (or (/= 0 (ite (= x$w_buff0_used 0) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$w_buff1_used 0) 1 0))) 1 0)) (/= 0 (ite (and (/= 0 (ite (= x$r_buff0_thd1 0) 1 0)) (/= 0 (ite (= x$r_buff1_thd1 0) 1 0))) 1 0))) 1 0)) x$r_buff1_thd1 (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd1)) 1 0)) 0 0))) 0) 0 1))</data>
+        </edge>
+        <edge source="N76" target="N77">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign __unbuffered_p0_EBX x)</data>
+        </edge>
+        <edge source="N77" target="N78">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x (ite (/= 0 x$flush_delayed) x$mem_tmp x))</data>
+        </edge>
+        <edge source="N78" target="N79">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign x$flush_delayed 0)</data>
+        </edge>
+        <edge source="N79" target="N80">
+            <data key="startline">763</data>
+            <data key="endline">763</data>
+            <data key="startoffset">33460</data>
+            <data key="endoffset">33483</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N80" target="N81">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N81" target="N82">
+            <data key="startline">764</data>
+            <data key="endline">764</data>
+            <data key="startoffset">33487</data>
+            <data key="endoffset">33512</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N82" target="N83">
+            <data key="startline">765</data>
+            <data key="endline">765</data>
+            <data key="startoffset">33516</data>
+            <data key="endoffset">33539</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N83" target="N84">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N84" target="N85">
+            <data key="startline">766</data>
+            <data key="endline">766</data>
+            <data key="startoffset">33543</data>
+            <data key="endoffset">33568</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N85" target="N86">
+            <data key="threadId">30</data>
+            <data key="stmt">(assign __unbuffered_cnt (+ __unbuffered_cnt 1))</data>
+        </edge>
+        <edge source="N86" target="N87">
+            <data key="startline">768</data>
+            <data key="endline">768</data>
+            <data key="startoffset">33615</data>
+            <data key="endoffset">33638</data>
+            <data key="threadId">30</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N87" target="N88">
+            <data key="startline">769</data>
+            <data key="endline">769</data>
+            <data key="startoffset">33642</data>
+            <data key="endoffset">33650</data>
+            <data key="threadId">30</data>
+            <data key="stmt">(assign T30::_::P0_ret 0)</data>
+            <data key="cSource">return 0;</data>
+        </edge>
+        <edge source="N88" target="N89">
+            <data key="threadId">30</data>
+        </edge>
+        <edge source="N89" target="N90">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N90" target="N91">
+            <data key="startline">803</data>
+            <data key="endline">803</data>
+            <data key="startoffset">35896</data>
+            <data key="endoffset">35921</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N91" target="N92">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) x$w_buff0 (ite (/= 0 (ite (and (/= 0 x$w_buff1_used) (/= 0 x$r_buff1_thd2)) 1 0)) x$w_buff1 x)))</data>
+        </edge>
+        <edge source="N92" target="N93">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff0_used (ite (= (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) 0 x$w_buff0_used) 0) 0 1))</data>
+        </edge>
+        <edge source="N93" target="N94">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$w_buff1_used (ite (= (ite (/= 0 (ite (or (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) (/= 0 (ite (and (/= 0 x$w_buff1_used) (/= 0 x$r_buff1_thd2)) 1 0))) 1 0)) 0 x$w_buff1_used) 0) 0 1))</data>
+        </edge>
+        <edge source="N94" target="N95">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff0_thd2 (ite (= (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) 0 x$r_buff0_thd2) 0) 0 1))</data>
+        </edge>
+        <edge source="N95" target="N96">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign x$r_buff1_thd2 (ite (= (ite (/= 0 (ite (or (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd2)) 1 0)) (/= 0 (ite (and (/= 0 x$w_buff1_used) (/= 0 x$r_buff1_thd2)) 1 0))) 1 0)) 0 x$r_buff1_thd2) 0) 0 1))</data>
+        </edge>
+        <edge source="N96" target="N97">
+            <data key="startline">809</data>
+            <data key="endline">809</data>
+            <data key="startoffset">36426</data>
+            <data key="endoffset">36449</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N97" target="N98">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N98" target="N99">
+            <data key="startline">810</data>
+            <data key="endline">810</data>
+            <data key="startoffset">36453</data>
+            <data key="endoffset">36478</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N99" target="N100">
+            <data key="threadId">32</data>
+            <data key="stmt">(assign __unbuffered_cnt (+ __unbuffered_cnt 1))</data>
+        </edge>
+        <edge source="N100" target="N101">
+            <data key="startline">812</data>
+            <data key="endline">812</data>
+            <data key="startoffset">36525</data>
+            <data key="endoffset">36548</data>
+            <data key="threadId">32</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N101" target="N102">
+            <data key="startline">813</data>
+            <data key="endline">813</data>
+            <data key="startoffset">36552</data>
+            <data key="endoffset">36560</data>
+            <data key="threadId">32</data>
+            <data key="stmt">(assign T32::_::P1_ret 0)</data>
+            <data key="cSource">return 0;</data>
+        </edge>
+        <edge source="N102" target="N103">
+            <data key="threadId">32</data>
+        </edge>
+        <edge source="N103" target="N104">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N104" target="N105">
+            <data key="startline">830</data>
+            <data key="endline">830</data>
+            <data key="startoffset">36770</data>
+            <data key="endoffset">36795</data>
+            <data key="threadId">0</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N105" target="N106">
+            <data key="threadId">0</data>
+            <data key="stmt">(assign main$tmp_guard0 (ite (= (ite (= __unbuffered_cnt 2) 1 0) 0) 0 1))</data>
+        </edge>
+        <edge source="N106" target="N107">
+            <data key="startline">832</data>
+            <data key="endline">832</data>
+            <data key="startoffset">36842</data>
+            <data key="endoffset">36865</data>
+            <data key="threadId">0</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N107" target="N108">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N108" target="N109">
+            <data key="startline">833</data>
+            <data key="endline">833</data>
+            <data key="startoffset">36869</data>
+            <data key="endoffset">36905</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assign T0::_::assume_abort_if_not::cond main$tmp_guard0)</data>
+            <data key="cSource">assume_abort_if_not(main$tmp_guard0);</data>
+        </edge>
+        <edge source="N109" target="N110">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N110" target="N111">
+            <data key="control">condition-false</data>
+            <data key="startline">4</data>
+            <data key="endline">4</data>
+            <data key="startoffset">107</data>
+            <data key="endoffset">126</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assume (= (ite (= T0::_::assume_abort_if_not::cond 0) 1 0) 0))</data>
+            <data key="cSource">if(!cond) {abort();}</data>
+        </edge>
+        <edge source="N111" target="N112">
+            <data key="startline">833</data>
+            <data key="endline">833</data>
+            <data key="startoffset">36869</data>
+            <data key="endoffset">36905</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assign T0::_::call_assume_abort_if_not_ret32 T0::_::assume_abort_if_not_ret)</data>
+            <data key="cSource">assume_abort_if_not(main$tmp_guard0);</data>
+        </edge>
+        <edge source="N112" target="N113">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N113" target="N114">
+            <data key="startline">834</data>
+            <data key="endline">834</data>
+            <data key="startoffset">36909</data>
+            <data key="endoffset">36934</data>
+            <data key="threadId">0</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N114" target="N115">
+            <data key="threadId">0</data>
+            <data key="stmt">(assign x (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd0)) 1 0)) x$w_buff0 (ite (/= 0 (ite (and (/= 0 x$w_buff1_used) (/= 0 x$r_buff1_thd0)) 1 0)) x$w_buff1 x)))</data>
+        </edge>
+        <edge source="N115" target="N116">
+            <data key="threadId">0</data>
+            <data key="stmt">(assign x$w_buff0_used (ite (= (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd0)) 1 0)) 0 x$w_buff0_used) 0) 0 1))</data>
+        </edge>
+        <edge source="N116" target="N117">
+            <data key="threadId">0</data>
+            <data key="stmt">(assign x$w_buff1_used (ite (= (ite (/= 0 (ite (or (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd0)) 1 0)) (/= 0 (ite (and (/= 0 x$w_buff1_used) (/= 0 x$r_buff1_thd0)) 1 0))) 1 0)) 0 x$w_buff1_used) 0) 0 1))</data>
+        </edge>
+        <edge source="N117" target="N118">
+            <data key="threadId">0</data>
+            <data key="stmt">(assign x$r_buff0_thd0 (ite (= (ite (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd0)) 1 0)) 0 x$r_buff0_thd0) 0) 0 1))</data>
+        </edge>
+        <edge source="N118" target="N119">
+            <data key="threadId">0</data>
+            <data key="stmt">(assign x$r_buff1_thd0 (ite (= (ite (/= 0 (ite (or (/= 0 (ite (and (/= 0 x$w_buff0_used) (/= 0 x$r_buff0_thd0)) 1 0)) (/= 0 (ite (and (/= 0 x$w_buff1_used) (/= 0 x$r_buff1_thd0)) 1 0))) 1 0)) 0 x$r_buff1_thd0) 0) 0 1))</data>
+        </edge>
+        <edge source="N119" target="N120">
+            <data key="startline">840</data>
+            <data key="endline">840</data>
+            <data key="startoffset">37439</data>
+            <data key="endoffset">37462</data>
+            <data key="threadId">0</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N120" target="N121">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N121" target="N122">
+            <data key="startline">841</data>
+            <data key="endline">841</data>
+            <data key="startoffset">37466</data>
+            <data key="endoffset">37491</data>
+            <data key="threadId">0</data>
+            <data key="cSource">__VERIFIER_atomic_begin();</data>
+        </edge>
+        <edge source="N122" target="N123">
+            <data key="threadId">0</data>
+            <data key="stmt">(assign main$tmp_guard1 (ite (= (ite (= (ite (and (/= 0 (ite (= __unbuffered_p0_EAX 1) 1 0)) (/= 0 (ite (= __unbuffered_p0_EBX 0) 1 0)) (/= 0 (ite (= __unbuffered_p1_EAX 1) 1 0)) (/= 0 (ite (= __unbuffered_p1_EBX 0) 1 0))) 1 0) 0) 1 0) 0) 0 1))</data>
+        </edge>
+        <edge source="N123" target="N124">
+            <data key="startline">843</data>
+            <data key="endline">843</data>
+            <data key="startoffset">37628</data>
+            <data key="endoffset">37651</data>
+            <data key="threadId">0</data>
+            <data key="cSource">__VERIFIER_atomic_end();</data>
+        </edge>
+        <edge source="N124" target="N125">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N125" target="N126">
+            <data key="startline">844</data>
+            <data key="endline">844</data>
+            <data key="startoffset">37655</data>
+            <data key="endoffset">37689</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assign T0::_::__VERIFIER_assert::expression main$tmp_guard1)</data>
+            <data key="cSource">__VERIFIER_assert(main$tmp_guard1);</data>
+        </edge>
+        <edge source="N126" target="N127">
+            <data key="threadId">0</data>
+        </edge>
+        <edge source="N127" target="N128">
+            <data key="control">condition-true</data>
+            <data key="startline">19</data>
+            <data key="endline">19</data>
+            <data key="startoffset">960</data>
+            <data key="endoffset">1011</data>
+            <data key="threadId">0</data>
+            <data key="stmt">(assume (/= (ite (= T0::_::__VERIFIER_assert::expression 0) 1 0) 0))</data>
+            <data key="cSource">if (!expression) { ERROR: {reach_error();abort();} }</data>
+        </edge>
+        <edge source="N128" target="N129"/>
+    </graph>
+</graphml>

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ def translate_to_c(filename, witness, mode):
                 [
                     "gcc",
                     "-w",
+                    "-Wno-implicit-function-declaration",
                     tmp.name,
                     os.path.dirname(__file__) + os.sep + "svcomp.c",
                     "-o",

--- a/svcomp.c
+++ b/svcomp.c
@@ -20,6 +20,7 @@
 #include <stddef.h>
 #include <stdatomic.h>
 #include <threads.h>
+#include <stdlib.h>
 
 void __VERIFIER_atomic_begin() {
 

--- a/tweaks.py
+++ b/tweaks.py
@@ -31,7 +31,7 @@ def reach_error(ast):
                 bitsize=None,
             )
             ast.ext.remove(node)
-            ast.ext.append(extern_decl)
+            ast.ext.insert(0, extern_decl)
 
 
 # This is a problem with some SV-COMP benchmarks


### PR DESCRIPTION
It is for now limited, but more or less if `varname = value` is present in an assumption made for a statement like `varname = __VERIFIER_nondet_...();`, we change the function call to `value`.

This is of course only sufficient where that given assigments is executed only once *(e.g., does not work if assignment is in a loop and assigned values differ)*.

This is a naive approach, but it is a good first step, so that ConcurrentWitness2Test can handle different kinds of non-determinism besides interleavings